### PR TITLE
Assign Select and Start buttons to language selection

### DIFF
--- a/src/js/controls/gamepad.js
+++ b/src/js/controls/gamepad.js
@@ -24,7 +24,7 @@ export default class GamepadControls extends Controls {
         this.modifyState(gp.index, "left", gp.axes[0] < -0.5 || (gp.buttons[14]?.pressed ?? false));
         this.modifyState(gp.index, "right", gp.axes[0] > 0.5 || (gp.buttons[15]?.pressed ?? false));
         this.modifyState(gp.index, "action", (gp.buttons[1]?.pressed ?? false) || (gp.buttons[2]?.pressed ?? false));
-        this.modifyState(gp.index, "language", gp.buttons[8]?.pressed ?? false);
+        this.modifyState(gp.index, "language", (gp.buttons[8]?.pressed ?? false) || (gp.buttons[9]?.pressed ?? false));
       });
   }
 


### PR DESCRIPTION
Some USB gamepad controllers don't expose the Select button on i(Pad)OS. Therefore, this patch make it possible to change the language using the Start button in addition to the Select button.

This PR does not include the compiled bundles since I had some troubles with the previous updates to the build system.